### PR TITLE
Follow some conventions

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,8 @@ Release history for Perl module Simple::IPInfo
     - Added this Changes file
     - Added "use 5.008", since the module uses utf8, and added the
       requirement to the metadata as well.
+    - Added "use strict" and "use warnings", plus minor tweaks so it
+      will run without warnings.
 
 0.05 2014-09-09 ABBYPAN
     - remove ^M

--- a/Changes
+++ b/Changes
@@ -1,0 +1,22 @@
+Release history for Perl module Simple::IPInfo
+
+0.06 2014-12-?? ABBYPAN
+    - Added this Changes file
+
+0.05 2014-09-09 ABBYPAN
+    - remove ^M
+    - ask ip loc
+    - ip loc parse script
+
+0.04 2014-08-28 ABBYPAN
+    - add asn example
+    - link to GitHub from META files (Gabor Szabo++)
+    - update read_table_ipinfo
+
+0.03 2014-08-25 ABBYPAN
+
+0.02 2014-08-14 ABBYPAN
+
+0.01 2014-04-30 ABBYPAN
+    - First release to CPAN
+

--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Release history for Perl module Simple::IPInfo
 
 0.06 2014-12-?? ABBYPAN
     - Added this Changes file
+    - Added "use 5.008", since the module uses utf8, and added the
+      requirement to the metadata as well.
 
 0.05 2014-09-09 ABBYPAN
     - remove ^M

--- a/dist.ini
+++ b/dist.ini
@@ -9,10 +9,11 @@ version = 0.06
 [@Basic]
   
 [Prereqs]
-Data::Validate::IP = 0
-JSON = 0
-Memoize = 0
-SimpleR::Reshape=0
+Data::Validate::IP  = 0
+JSON                = 0
+Memoize             = 0
+SimpleR::Reshape    = 0
+perl                = 5.008
 
 [MetaResources]
 repository.web = https://github.com/abbypan/Simple-IPInfo

--- a/dist.ini
+++ b/dist.ini
@@ -4,7 +4,7 @@ license = Perl_5
 copyright_holder = Abby Pan 
 copyright_year   = 2014
 
-version = 0.05
+version = 0.06
  
 [@Basic]
   

--- a/lib/Simple/IPInfo.pm
+++ b/lib/Simple/IPInfo.pm
@@ -1,5 +1,7 @@
 # ABSTRACT: Get IP/IPList Info (location, as number, etc)
 package Simple::IPInfo;
+
+use 5.008;
 require Exporter;
 @ISA    = qw(Exporter);
 @EXPORT = qw(

--- a/lib/Simple/IPInfo.pm
+++ b/lib/Simple/IPInfo.pm
@@ -2,9 +2,10 @@
 package Simple::IPInfo;
 
 use 5.008;
-require Exporter;
-@ISA    = qw(Exporter);
-@EXPORT = qw(
+use strict;
+use warnings;
+use parent 'Exporter';
+our @EXPORT = qw(
   get_ip_loc
   get_ip_as
   get_ip_info


### PR DESCRIPTION
Hi,

These changes get your distribution to follow some of the conventions for modern CPAN/Perl distributions:

 * Added a Changes file, with entries for past releases taken from git log. The contents of this file will be presented by MetaCPAN, and the distribution's home page will show the extract for the most recent release.
 * Explicitly specify 5.8.0 as the minimum version of Perl (due to use of utf8).
 * Added strict and warnings, and made some minor changes so it wouldn't result in errors / warnings.

Neil
